### PR TITLE
Change the value of MAX_GLITCH_COUNT

### DIFF
--- a/src/components/glitch-image/glitch-image.tsx
+++ b/src/components/glitch-image/glitch-image.tsx
@@ -4,7 +4,7 @@ import { pickRandomFromRange } from "../../utils/utils";
 
 const INITIAL_WAIT_TIME = 1000;
 const CLEAR_TIME = 100;
-const MAX_GLITCH_COUNT = 4;
+const MAX_GLITCH_COUNT = 1;
 const MAX_GLITCH_SEQUENCE_COUNT = 3;
 const MAX_GLITCH_FREQUENCY_MS = 2000;
 const MAX_GLITCH_WIDTH = 5;


### PR DESCRIPTION
# Issue
> #5
> In some frames image fully hidden, can i prevent that?

Temporarily solve the problem of images becoming momentarily invisible.

# Summary
This fix will make glitch-image a little less glitchy.
MAX_GLITCH_COUNT will be fixed to 1, so it's a bit lame, but it's much more on fleek than being buggy, right?
